### PR TITLE
Add snapshot releases

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -30,5 +30,41 @@ jobs:
           lfs: true
       - name: Select Xcode 11.4
         run: sudo xcode-select -s /Applications/Xcode_11.4.app
+      - name: Cache Kotlin Native dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.konan/kotlin-native-macos-*
+            ~/.konan/dependencies
+          key: ${{ runner.os }}-kotlin-native-${{ hashFiles('build.gradle') }}
+          restore-keys: |
+            ${{ runner.os }}-kotlin-native-
       - name: Tests
         run: set -o pipefail && xcodebuild -project sample-ios/SampleiOS.xcodeproj -scheme SampleiOS -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 11,OS=13.4' test | xcpretty
+
+  publish:
+    name: Publish Snapshot Release
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs: [android_tests, ios_tests]
+    runs-on:  macOS-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          lfs: true
+      - name: Cache Kotlin Native dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.konan/kotlin-native-macos-*
+            ~/.konan/dependencies
+          key: ${{ runner.os }}-kotlin-native-${{ hashFiles('build.gradle') }}
+          restore-keys: |
+            ${{ runner.os }}-kotlin-native-
+      - name: Select Xcode 11.4
+        run: sudo xcode-select -s /Applications/Xcode_11.4.app
+      - name: Publish artifacts
+        env:
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+        run: ./gradlew kuiks-core:publish

--- a/build.gradle
+++ b/build.gradle
@@ -15,10 +15,20 @@ buildscript {
     }
 }
 
+plugins {
+    id 'pl.allegro.tech.build.axion-release' version '1.12.0'
+}
+
+scmVersion {
+    tag {
+        prefix = ""
+    }
+}
+
 allprojects {
 
     group 'dev.michallaskowski.kuiks'
-    version = '0.0.1'
+    version = scmVersion.version
 
     repositories {
         mavenCentral()

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -10,7 +10,7 @@ publishing {
             name = "kuiks-core"
             description = "Kotlin Multiplatform library for UI testing, " +
                     "wrapping Espresso and XCTest."
-            url = "https://github.com/michallaskowski/mokttp"
+            url = "https://github.com/michallaskowski/kuiks"
             licenses {
                 license {
                     name = 'The Apache License, Version 2.0'

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -1,0 +1,57 @@
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
+
+publishing {
+    publications.all { publication ->
+        def publicationName = publication.name == 'kotlinMultiplatform' ? "common" : publication.name
+        publication.artifactId = "kuiks-core-$publicationName"
+
+        pom {
+            name = "kuiks-core"
+            description = "Kotlin Multiplatform library for UI testing, " +
+                    "wrapping Espresso and XCTest."
+            url = "https://github.com/michallaskowski/mokttp"
+            licenses {
+                license {
+                    name = 'The Apache License, Version 2.0'
+                    url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                }
+            }
+            scm {
+                url = "https://github.com/michallaskowski/kuiks.git"
+            }
+            developers {
+                developer {
+                    id = 'michallaskowski'
+                    name = 'Michal Laskowski'
+                    email = 'michal@michallaskowski.dev'
+                }
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            name = "central"
+            def snapshotRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots"
+            def stagingRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+            url = version.endsWith('SNAPSHOT') ? snapshotRepoUrl : stagingRepoUrl
+            credentials {
+                username = System.getenv("MAVEN_USERNAME")
+                password = System.getenv("MAVEN_PASSWORD")
+            }
+        }
+    }
+}
+
+signing {
+    required { isReleaseBuild() }
+    if (isReleaseBuild()) {
+        useInMemoryPgpKeys(System.getenv("PGP_SIGNING_KEY"), System.getenv("PGP_SIGNING_PASSWORD"))
+        sign publishing.publications
+    }
+}
+
+def isReleaseBuild() {
+    return !scmVersion.version.contains("SNAPSHOT")
+}

--- a/sharedCode/build.gradle
+++ b/sharedCode/build.gradle
@@ -3,6 +3,8 @@ apply plugin: 'maven'
 apply plugin: 'maven-publish'
 apply plugin: 'com.android.library'
 
+apply from: rootProject.file("gradle/publish.gradle")
+
 android {
     compileSdkVersion 29
     defaultConfig {
@@ -29,10 +31,6 @@ android {
 }
 
 kotlin {
-    android {
-        publishLibraryVariants("release", "debug")
-    }
-
     targets {
         ios('iOS') {
             binaries {
@@ -53,7 +51,9 @@ kotlin {
             }
         }
 
-        fromPreset(presets.android, 'android')
+        fromPreset(presets.android, 'android') {
+            publishLibraryVariants("release", "debug")
+        }
     }
 
     sourceSets {


### PR DESCRIPTION
Maven publishing for snapshots, similar to the setup that was done in https://github.com/michallaskowski/mokttp.
Snapshots only for now, until there is enough to publish a first 0.1.0 release. That will by known by using kuiks in a different, small project.